### PR TITLE
✨  Slackへ AWS ChatBot を使用したデプロイ通知の機能を追加する

### DIFF
--- a/components/cicd/sns.tf
+++ b/components/cicd/sns.tf
@@ -1,0 +1,27 @@
+# 詳しくは公式の Example を参考にすること
+#   https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codestarnotifications_notification_rule#example-usage
+
+# SNSトピックの作成
+resource "aws_sns_topic" "codeseries_notif" {
+  name = "codeseries-notifications-for-cicd"
+}
+
+# SNSトピック用のアクセスポリシーを定義
+data "aws_iam_policy_document" "notif_access" {
+  statement {
+    actions = ["sns:Publish"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["codestar-notifications.amazonaws.com"]
+    }
+
+    resources = [aws_sns_topic.codeseries_notif.arn]
+  }
+}
+
+# SNSトピックにアクセスポリシーを紐付ける
+resource "aws_sns_topic_policy" "default" {
+  arn    = aws_sns_topic.codeseries_notif.arn
+  policy = data.aws_iam_policy_document.notif_access.json
+}

--- a/components/cicd/sns.tf
+++ b/components/cicd/sns.tf
@@ -25,3 +25,22 @@ resource "aws_sns_topic_policy" "default" {
   arn    = aws_sns_topic.codeseries_notif.arn
   policy = data.aws_iam_policy_document.notif_access.json
 }
+
+# Codeシリーズのデベロッパー用ツールの通知ルールが作成される
+resource "aws_codestarnotifications_notification_rule" "build" {
+  detail_type    = "BASIC"
+  # CodeBuildのイベントについてははこちらのドキュメントを確認すること
+  #   https://docs.aws.amazon.com/ja_jp/dtconsole/latest/userguide/concepts.html#events-ref-buildproject
+  event_type_ids = [
+    "codebuild-project-build-state-failed",
+    "codebuild-project-build-phase-failure",
+    "codebuild-project-build-phase-success",
+    ]
+
+  name     = "codebuild-notify-for-project"
+  resource = aws_codebuild_project.continuous_apply.arn
+
+  target {
+    address = aws_sns_topic.codeseries_notif.arn
+  }
+}

--- a/components/cicd/sns.tf
+++ b/components/cicd/sns.tf
@@ -28,14 +28,14 @@ resource "aws_sns_topic_policy" "default" {
 
 # Codeシリーズのデベロッパー用ツールの通知ルールが作成される
 resource "aws_codestarnotifications_notification_rule" "build" {
-  detail_type    = "BASIC"
+  detail_type = "BASIC"
   # CodeBuildのイベントについてははこちらのドキュメントを確認すること
   #   https://docs.aws.amazon.com/ja_jp/dtconsole/latest/userguide/concepts.html#events-ref-buildproject
+  #   NOTE: phase の通知をするとすべてのイベントの通知を行うのですごく邪魔なので state だけ通知の対象とする
   event_type_ids = [
     "codebuild-project-build-state-failed",
-    "codebuild-project-build-phase-failure",
-    "codebuild-project-build-phase-success",
-    ]
+    "codebuild-project-build-state-succeeded",
+  ]
 
   name     = "codebuild-notify-for-project"
   resource = aws_codebuild_project.continuous_apply.arn

--- a/components/ec2/main.tf
+++ b/components/ec2/main.tf
@@ -3,6 +3,6 @@ resource "aws_instance" "example" {
   instance_type = "t3.nano"
 
   tags = {
-    Name = "example123"
+    Name = "example"
   }
 }


### PR DESCRIPTION
# AWS ChatBot によるSlack通知

- AWS SNS の追加
- CodeBuild のイベントの通知を SNS に紐付ける